### PR TITLE
Add DeckBuilder GUI for lyric deck creation and editing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist/
 # Virtual Environments
 venv/
 .env/
+.env
 
 
 # CSV files

--- a/DeckBuilder/.env.example
+++ b/DeckBuilder/.env.example
@@ -1,0 +1,3 @@
+
+# Copy this file to .env and replace with your Genius API key
+GENIUS_API_KEY=your_api_key_here

--- a/DeckBuilder/__main__.py
+++ b/DeckBuilder/__main__.py
@@ -1,0 +1,8 @@
+# DeckBuilder/__main__.py
+from .deck_builder_gui import DeckBuilderApp
+import tkinter as tk
+
+if __name__ == "__main__":
+    root = tk.Tk()
+    app = DeckBuilderApp(root)
+    root.mainloop()

--- a/DeckBuilder/api_debug.py
+++ b/DeckBuilder/api_debug.py
@@ -1,0 +1,4 @@
+from DeckBuilder.genius_api import search_song
+
+song = search_song("Bye Bye Bye", "NSYNC")
+print(song.lyrics if song else "No lyrics found.")

--- a/DeckBuilder/api_debug.py
+++ b/DeckBuilder/api_debug.py
@@ -1,4 +1,4 @@
-from DeckBuilder.genius_api import search_song
+from genius_api import search_song
 
 song = search_song("Bye Bye Bye", "NSYNC")
 print(song.lyrics if song else "No lyrics found.")

--- a/DeckBuilder/deck_builder_gui.py
+++ b/DeckBuilder/deck_builder_gui.py
@@ -1,0 +1,164 @@
+import tkinter as tk
+from tkinter import ttk, messagebox
+from DeckBuilder.genius_api import search_general, search_song
+
+class DeckBuilderApp:
+    def __init__(self, root):
+        self.root = root
+        self.root.title("Lyric Deck Builder")
+        self.root.geometry("800x900")
+
+        self.deck_entries = []  # Stores final prompt-answer pairs
+
+        self._build_search_section()
+        self._build_search_results()
+        self._build_lyric_viewer()
+        self._build_snippet_entry()
+        self._build_song_deck_preview()
+
+    def _build_search_section(self):
+        frame = ttk.LabelFrame(self.root, text="Search Songs")
+        frame.pack(fill="x", padx=10, pady=10)
+
+        self.search_var = tk.StringVar()
+        search_entry = ttk.Entry(frame, textvariable=self.search_var, width=50)
+        search_entry.pack(side="left", padx=5)
+
+        search_btn = ttk.Button(frame, text="Search", command=self.perform_search)
+        search_btn.pack(side="left", padx=5)
+
+    def _build_search_results(self):
+        frame = ttk.LabelFrame(self.root, text="Search Results")
+        frame.pack(fill="both", expand=True, padx=10, pady=10)
+
+        self.results_listbox = tk.Listbox(frame, height=10)
+        self.results_listbox.pack(side="left", fill="both", expand=True)
+        self.results_listbox.bind("<<ListboxSelect>>", self.on_result_select)
+
+        scrollbar = ttk.Scrollbar(frame, orient="vertical", command=self.results_listbox.yview)
+        scrollbar.pack(side="right", fill="y")
+        self.results_listbox.config(yscrollcommand=scrollbar.set)
+
+        self.add_btn = ttk.Button(self.root, text="+ Add to Deck", command=self.add_selected_to_deck)
+        self.add_btn.pack(pady=5)
+
+    def _build_lyric_viewer(self):
+        frame = ttk.LabelFrame(self.root, text="Lyrics Viewer")
+        frame.pack(fill="both", expand=True, padx=10, pady=10)
+
+        fetch_btn = ttk.Button(frame, text="Fetch Lyrics", command=self.fetch_lyrics)
+        fetch_btn.pack(anchor="w", padx=5, pady=5)
+
+        self.lyrics_text = tk.Text(frame, wrap="word", height=15)
+        self.lyrics_text.pack(fill="both", expand=True, padx=5, pady=5)
+        self.lyrics_text.insert("1.0", "Lyrics will appear here...")
+
+    def _build_snippet_entry(self):
+        frame = ttk.LabelFrame(self.root, text="Add Prompt → Answer Pair")
+        frame.pack(fill="x", padx=10, pady=10)
+
+        ttk.Label(frame, text="Lyric Snippet (Prompt):").pack(anchor="w")
+        self.prompt_entry = tk.Text(frame, height=2, wrap="word")
+        self.prompt_entry.pack(fill="x", padx=5, pady=2)
+
+        ttk.Label(frame, text="Next Line (Answer):").pack(anchor="w")
+        self.answer_entry = tk.Text(frame, height=2, wrap="word")
+        self.answer_entry.pack(fill="x", padx=5, pady=2)
+
+        add_btn = ttk.Button(frame, text="Add Prompt → Answer", command=self.store_snippet_pair)
+        add_btn.pack(pady=5)
+
+    def _build_song_deck_preview(self):
+        frame = ttk.LabelFrame(self.root, text="Deck Preview")
+        frame.pack(fill="both", expand=True, padx=10, pady=10)
+
+        self.deck_listbox = tk.Listbox(frame, height=10)
+        self.deck_listbox.pack(side="left", fill="both", expand=True)
+
+        scrollbar = ttk.Scrollbar(frame, orient="vertical", command=self.deck_listbox.yview)
+        scrollbar.pack(side="right", fill="y")
+        self.deck_listbox.config(yscrollcommand=scrollbar.set)
+
+    def perform_search(self):
+        query = self.search_var.get()
+        if not query:
+            messagebox.showwarning("Missing Input", "Please enter a search query.")
+            return
+
+        self.results_listbox.delete(0, tk.END)
+        self.search_results = search_general(query)
+
+        if not self.search_results:
+            messagebox.showinfo("No Results", "No songs found.")
+            return
+
+        for hit in self.search_results['hits']:
+            song = hit['result']
+            title = song['title']
+            artist = song['primary_artist']['name']
+            self.results_listbox.insert(tk.END, f"{title} — {artist}")
+
+    def on_result_select(self, event):
+        selection = self.results_listbox.curselection()
+        if not selection:
+            return
+        index = selection[0]
+        hit = self.search_results['hits'][index]['result']
+        self.selected_song = {
+            'title': hit['title'],
+            'artist': hit['primary_artist']['name']
+        }
+
+    def fetch_lyrics(self):
+        self.lyrics_text.delete("1.0", tk.END)
+        if not hasattr(self, 'selected_song'):
+            self.lyrics_text.insert("1.0", "No song selected!")
+            return
+
+        title = self.selected_song['title']
+        artist = self.selected_song['artist']
+        song = search_song(title, artist)
+        if song and song.lyrics:
+            self.lyrics_text.insert("1.0", song.lyrics)
+        else:
+            self.lyrics_text.insert("1.0", "Lyrics not found.")
+
+    def add_selected_to_deck(self):
+        if not hasattr(self, 'selected_song'):
+            messagebox.showwarning("No Selection", "Please select a song first.")
+            return
+
+        title = self.selected_song['title']
+        artist = self.selected_song['artist']
+        self.deck_listbox.insert(tk.END, f"{title} — {artist}")
+
+    def store_snippet_pair(self):
+        if not hasattr(self, 'selected_song'):
+            messagebox.showwarning("No Song Selected", "Please select a song before adding a lyric snippet.")
+            return
+
+        prompt = self.prompt_entry.get("1.0", tk.END).strip()
+        answer = self.answer_entry.get("1.0", tk.END).strip()
+
+        if not prompt or not answer:
+            messagebox.showwarning("Missing Input", "Please provide both a prompt and an answer.")
+            return
+
+        entry = {
+            "song_title": self.selected_song['title'],
+            "artist": self.selected_song['artist'],
+            "prompt": prompt,
+            "answer": answer
+        }
+        self.deck_entries.append(entry)
+        display_text = f"{entry['song_title']} — {entry['prompt']} → {entry['answer']}"
+        self.deck_listbox.insert(tk.END, display_text)
+
+        # Clear input fields
+        self.prompt_entry.delete("1.0", tk.END)
+        self.answer_entry.delete("1.0", tk.END)
+
+if __name__ == "__main__":
+    root = tk.Tk()
+    app = DeckBuilderApp(root)
+    root.mainloop()

--- a/DeckBuilder/deck_builder_gui.py
+++ b/DeckBuilder/deck_builder_gui.py
@@ -88,6 +88,8 @@ class DeckBuilderApp:
         delete_btn.pack(side="left", padx=5)
 
         export_btn = ttk.Button(btn_frame, text="Export to CSV", command=self.export_to_csv)
+        import_btn = ttk.Button(btn_frame, text="Import from CSV", command=self.import_from_csv)
+        import_btn.pack(side="right", padx=5)
         export_btn.pack(side="right", padx=5)
 
     def perform_search(self):
@@ -131,7 +133,7 @@ class DeckBuilderApp:
         song = search_song(title, artist)
         if song:
             self.selected_song['release_year'] = getattr(song, 'release_year', '')
-            self.selected_song['album'] = getattr(song.album, 'name', '') if hasattr(song, 'album') else ''
+            self.selected_song['album'] = getattr(song.album, 'name', '') if hasattr(song, 'album') and song.album else ''
         if song and song.lyrics:
             self.lyrics_text.insert("1.0", song.lyrics)
         else:
@@ -204,6 +206,22 @@ class DeckBuilderApp:
         index = selection[0]
         self.deck_listbox.delete(index)
         del self.deck_entries[index]
+
+    def import_from_csv(self):
+        file_path = filedialog.askopenfilename(filetypes=[("CSV files", "*.csv")])
+        if not file_path:
+            return
+
+        try:
+            with open(file_path, mode="r", newline="", encoding="utf-8") as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    self.deck_entries.append(row)
+                    display_text = f"{row['song_title']} — {row['lyric_snippet']} → {row['next_line']}"
+                    self.deck_listbox.insert(tk.END, display_text)
+            messagebox.showinfo("Import Successful", f"Deck imported from {file_path}")
+        except Exception as e:
+            messagebox.showerror("Import Failed", str(e))
 
     def export_to_csv(self):
         if not self.deck_entries:

--- a/DeckBuilder/genius_api.py
+++ b/DeckBuilder/genius_api.py
@@ -1,0 +1,29 @@
+import os
+from dotenv import load_dotenv
+import lyricsgenius
+
+# Load environment variables from .env file
+load_dotenv()
+
+# Try to get the API key from environment
+api_key = os.getenv("GENIUS_API_KEY")
+
+# Optional fallback prompt
+if not api_key:
+    print("⚠️ No Genius API key found in .env")
+    api_key = input("Please enter your Genius API key: ")
+
+# Initialize the Genius client
+genius = lyricsgenius.Genius(api_key)
+
+# Optional: Clean up results
+genius.skip_non_songs = True
+genius.remove_section_headers = True
+genius.excluded_terms = ["(Remix)", "(Live)"]
+
+# Example usage
+def search_song(title, artist=None):
+    return genius.search_song(title, artist)
+
+def search_general(query, max_songs=10):
+    return genius.search_songs(query, per_page=max_songs)

--- a/DeckBuilder/genius_api.py
+++ b/DeckBuilder/genius_api.py
@@ -5,25 +5,62 @@ import lyricsgenius
 # Load environment variables from .env file
 load_dotenv()
 
-# Try to get the API key from environment
-api_key = os.getenv("GENIUS_API_KEY")
+# Get Genius API token from environment variable
+GENIUS_API_KEY = os.getenv("GENIUS_API_KEY")
 
-# Optional fallback prompt
-if not api_key:
-    print("⚠️ No Genius API key found in .env")
-    api_key = input("Please enter your Genius API key: ")
-
-# Initialize the Genius client
-genius = lyricsgenius.Genius(api_key)
-
-# Optional: Clean up results
-genius.skip_non_songs = True
+# Initialize the Genius API client
+# Remove section headers like [Chorus], [Verse], etc.
+# Skip non-song results (like interviews)
+genius = lyricsgenius.Genius(GENIUS_API_KEY)
 genius.remove_section_headers = True
+genius.skip_non_songs = True
 genius.excluded_terms = ["(Remix)", "(Live)"]
 
-# Example usage
-def search_song(title, artist=None):
-    return genius.search_song(title, artist)
-
 def search_general(query, max_songs=10):
-    return genius.search_songs(query, per_page=max_songs)
+    """
+    Search for songs using a general query.
+
+    Args:
+        query (str): The search string.
+        max_songs (int): Maximum number of songs to return.
+
+    Returns:
+        dict: The search results including song metadata.
+    """
+    try:
+        return genius.search_songs(query, per_page=max_songs)
+    except Exception as e:
+        print(f"Search failed: {e}")
+        return None
+
+def search_song(title, artist=None):
+    """
+    Search for a specific song by title and optionally artist, and fetch lyrics and release year.
+
+    Args:
+        title (str): Song title.
+        artist (str): Optional artist name.
+
+    Returns:
+        object: lyricsgenius Song object with added 'release_year' attribute if available.
+    """
+    try:
+        song = genius.search_song(title, artist)
+        if song:
+            # Attempt to extract release year from release_date if available
+            release_date = getattr(song, 'release_date', None)
+            if release_date and isinstance(release_date, str):
+                song.release_year = release_date.split('-')[0]  # Extract only the year part
+            else:
+                song.release_year = ""
+
+            # Extract album name if available
+            song.album = getattr(song, 'album', {}).get('name', '') if hasattr(song, 'album') and song.album else ""
+
+            return song
+        return None
+
+
+    except Exception as e:
+        print(f"Failed to fetch song: {e}")
+        return None

--- a/DeckBuilder/genius_api.py
+++ b/DeckBuilder/genius_api.py
@@ -16,7 +16,7 @@ genius.remove_section_headers = True
 genius.skip_non_songs = True
 genius.excluded_terms = ["(Remix)", "(Live)"]
 
-def search_general(query, max_songs=10):
+def search_general(query, max_songs=20):
     """
     Search for songs using a general query.
 
@@ -55,11 +55,10 @@ def search_song(title, artist=None):
                 song.release_year = ""
 
             # Extract album name if available
-            song.album = getattr(song, 'album', {}).get('name', '') if hasattr(song, 'album') and song.album else ""
+            song.album = song.album.name if hasattr(song, 'album') and hasattr(song.album, 'name') else ""
 
             return song
         return None
-
 
     except Exception as e:
         print(f"Failed to fetch song: {e}")

--- a/README.md
+++ b/README.md
@@ -125,6 +125,57 @@ Tests are located in the `/tests` directory and cover:
 
 ---
 
+# 📦 DeckBuilder Tool
+
+The `DeckBuilder` GUI is a standalone tool for creating lyric guessing decks based on Genius lyrics. It allows you to:
+
+- 🔍 Search for songs using the Genius API
+- 📄 View and select lyrics line-by-line
+- ✍️ Manually define prompt → answer pairs
+- 🧾 Save and load decks as CSV
+- 🖋 Edit or delete deck entries
+- 📅 Capture metadata like release year and album
+
+## 🔧 Setup
+
+1. Make sure you have a `.env` file in the root of your project with your Genius API token:
+
+   ```env
+   GENIUS_API_KEY=your_access_token_here
+   ```
+
+2. Install required dependencies:
+
+   ```bash
+   pip install lyricsgenius python-dotenv
+   ```
+
+3. Then run the GUI with:
+
+   ```bash
+   python -m DeckBuilder
+   ```
+
+> This will launch a Tkinter-based interface for building decks.
+
+## 🗂 CSV Format
+
+Each row in your exported deck file will look like:
+
+| lyric_snippet | next_line | song_title | artist | release_year | album |
+|---------------|-----------|------------|--------|---------------|--------|
+
+You can re-import this file at any time to continue editing.
+
+
+
+
+
+
+
+
+
+
 ## 🛣 Roadmap
 
 Planned features include:


### PR DESCRIPTION
This branch introduces a standalone DeckBuilder tool that allows users to:

- Search for songs via Genius API
- View full lyrics before selecting snippets
- Manually define prompt → answer lyric pairs
- Save and load decks as CSV
- Edit, delete, and re-import deck entries
- Capture metadata including song title, artist, release year, and album

Also includes README_deckbuilder.md with setup and usage instructions.
